### PR TITLE
fix: Fix TypeScript errors for production build

### DIFF
--- a/src/components/marketplace/PackageViewer.tsx
+++ b/src/components/marketplace/PackageViewer.tsx
@@ -43,7 +43,7 @@ import remarkGfm from 'remark-gfm'
 
 interface PackageViewerProps {
   packageName: string
-  packageType: 'preset' | 'plugin' | 'command'
+  packageType: 'preset' | 'plugin' | 'command' | 'subagent'
   onBack: () => void
 }
 
@@ -830,7 +830,7 @@ export default function PackageViewer({ packageName, packageType, onBack }: Pack
               <div className="space-y-2">
                 {(() => {
                   // Get all versions from packageInfo
-                  let versions = []
+                  let versions: string[] = []
                   if (packageInfo?.versions) {
                     versions = Object.keys(packageInfo.versions)
                   } else if (packageInfo?.time) {


### PR DESCRIPTION
## Summary
This PR fixes TypeScript compilation errors that prevent the production build from completing successfully.

## Changes
- Add explicit type annotation for `versions` array in PackageViewer component
- Add 'subagent' to PackageViewerProps packageType union type

## Why is this needed?
The main branch currently fails to build in production due to TypeScript errors. This fix ensures the application can be deployed.

## Test Results
✅ `npm run build` completes successfully
✅ All static pages generated correctly

🤖 Generated with [Claude Code](https://claude.ai/code)