### PR TITLE
fix: Configure Next.js static export for GitHub Pages deployment

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'export',
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
## 🚨 Critical Fix for GitHub Pages Deployment

This PR fixes the deployment failure that prevents the site from being published to GitHub Pages.

## Problem
The GitHub Actions workflow was failing with:
```
tar: out: Cannot open: No such file or directory
```

## Root Cause
Next.js 14 doesn't generate the `out` directory by default. It requires explicit configuration with `output: 'export'` to generate static files.

## Solution
Added `output: 'export'` to `next.config.js` to enable static export mode.

## Testing
✅ Verified locally that `npm run build` generates the `out` directory
✅ Confirmed all pages are generated correctly:
- Homepage
- All documentation pages
- All marketplace pages (presets, plugins, commands, subagents)

## Impact
Once merged, the GitHub Actions deployment workflow will successfully:
1. Build the static site
2. Generate the `out` directory
3. Upload artifacts to GitHub Pages
4. Deploy the site

🤖 Generated with [Claude Code](https://claude.ai/code)