### PR TITLE
fix: Add basePath and assetPrefix for GitHub Pages deployment

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  basePath: '/hugsy-website',
+  assetPrefix: '/hugsy-website',
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
The site is deployed to github.io/hugsy-website/ subdirectory, not the root. Without basePath and assetPrefix, CSS and JavaScript assets fail to load (404 errors).

This configuration ensures:
- All asset paths are prefixed with /hugsy-website/
- Links and navigation work correctly within the subdirectory
- CSS and JS files load from the correct paths